### PR TITLE
Fix Laravel 12 Schema::connection() compatibility

### DIFF
--- a/migrations/2024_01_01_000000_create_developer_logs_table.php
+++ b/migrations/2024_01_01_000000_create_developer_logs_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         $tableName = config('devlogger.table_name', 'developer_logs');
         $connection = config('devlogger.database_connection', null);
 
-        $schema = $connection ? Schema::connection($connection) : Schema::connection();
+        $schema = $connection ? Schema::connection($connection) : Schema;
         
         $schema->create($tableName, function (Blueprint $table) {
             $table->id();
@@ -52,7 +52,7 @@ return new class extends Migration
         $tableName = config('devlogger.table_name', 'developer_logs');
         $connection = config('devlogger.database_connection', null);
 
-        $schema = $connection ? Schema::connection($connection) : Schema::connection();
+        $schema = $connection ? Schema::connection($connection) : Schema;
         
         $schema->dropIfExists($tableName);
     }


### PR DESCRIPTION
This maintains backward compatibility while fixing the Laravel 12 issue. When a specific connection is configured, it will use Schema::connection($connection), and when no connection is specified (null), it will use the default Schema facade directly.